### PR TITLE
Update Stack.tsx to match canonical EL impl

### DIFF
--- a/src/layouts/Stack.tsx
+++ b/src/layouts/Stack.tsx
@@ -28,6 +28,11 @@ const Stack = styled.div<StackProps>`
   }
 
   ${({ splitAfter }) => splitAfter ? `
+
+    .stack-l:only-child {
+      height: 100%;
+    }
+
     .stack-l > :nth-child(${splitAfter}) {
       margin-bottom: auto;
     }`


### PR DESCRIPTION
Every-Layout's Stack.js implementation includes this rule for the :only-child selector.
Not sure yet if it's needed; _marking_ potential changes / diffs in canonical EL WC / es5 impl vs react-every-layout's tsx.